### PR TITLE
Use the readthedocs theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,7 @@
+# Dependencies to render the documentation, **not** to run 
+# the pipeline. Software dependencies should be handled by 
+# Snakemake for the sake of reproducibility 
+
+Sphinx==3.5.2
+sphinx-rtd-theme==0.5.1
+myst-parser==0.13.5


### PR DESCRIPTION
Use the standard readthedocs theme: https://sphinx-rtd-theme.readthedocs.io/en/stable/
@Simon If I remember correctly , you'll need to change the requirements file to `requirements-docs.txt` on the readthedocs control panel